### PR TITLE
(fix: equipment details) container spacing and inoperable equipment overflow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,16 +32,16 @@ rux-container footer[slot='footer'] {
 
 .contacts-table {
   grid-area: contacts-table;
-  max-height: 35rem;
+  max-height: 37rem;
   overflow: hidden;
-  margin-block: var(--spacing-3);
+  margin-block-start: var(--spacing-4);
 }
 
 .alerts {
   grid-area: alerts;
-  max-height: 35rem;
+  max-height: 37rem;
   overflow: hidden;
-  margin-block: var(--spacing-3);
+  margin-block-start: var(--spacing-4);
 }
 
 .equipment-tree {

--- a/src/Components/ContactsList/ContactsTable.css
+++ b/src/Components/ContactsList/ContactsTable.css
@@ -1,5 +1,5 @@
 .contacts-table {
-  padding-left: var(--spacing-3);
+  padding-left: var(--spacing-4);
   height: 100%;
   overflow: hidden;
   display: flex;

--- a/src/Components/ContactsList/ContactsTable.tsx
+++ b/src/Components/ContactsList/ContactsTable.tsx
@@ -105,7 +105,6 @@ const ContactsTable = () => {
   }, [filteredState, filterContacts, searchValue]);
 
   return (
-    <main className='contacts page'>
       <RuxContainer className='contacts-table'>
         <span slot='header'>Current Contacts</span>
         <div slot='header'>
@@ -152,7 +151,6 @@ const ContactsTable = () => {
         </div>
         <Table columnDefs={columnDefs} filteredData={filteredContacts} />
       </RuxContainer>
-    </main>
   );
 };
 

--- a/src/Components/Dashboard/DashboardPage.css
+++ b/src/Components/Dashboard/DashboardPage.css
@@ -33,4 +33,5 @@
 #inoperable-equipment-panel,
 #equipment-panel {
   grid-area: tab-panel;
+  overflow: auto;
 }

--- a/src/Components/EquipmentDetailsPanel/EquipmentDetailsPanel.css
+++ b/src/Components/EquipmentDetailsPanel/EquipmentDetailsPanel.css
@@ -1,6 +1,5 @@
 #equipment-panel:not(.hidden-panel) {
   height: 100%;
-  overflow: auto;
   display: grid;
   grid-template-rows: auto auto;
   grid-template-areas:
@@ -11,6 +10,10 @@
 .equipment-details {
   height: 100%;
   width: 100%;
+}
+
+.equipment-details::part(body) {
+  overflow: auto;
 }
 
 .equipment-details_wrapper {

--- a/src/Components/InoperableEquipment/InoperableEquipment.css
+++ b/src/Components/InoperableEquipment/InoperableEquipment.css
@@ -5,6 +5,7 @@
 
 .inoperable-equipment::part(body) {
   gap: var(--spacing-4);
+  overflow: auto;
 }
 
 .inoperable-equipment span {

--- a/src/Components/MaintenancePanel/MaintenancePanel.css
+++ b/src/Components/MaintenancePanel/MaintenancePanel.css
@@ -8,7 +8,6 @@ rux-container.jobs-section {
   flex-wrap: wrap;
   flex-direction: row;
   display: inline-block;
-  padding: var(--spacing-3) var(--spacing-3) var(--spacing-0) var(--spacing-3);
 }
 
 rux-container.jobs-section h2 {
@@ -45,7 +44,7 @@ rux-container.schedule-job-wrapper {
 }
 
 .maintenance-history-panel {
-  padding: var(--spacing-3);
+  padding-block-start: var(--spacing-4);
 }
 
 .maintenance-wrapper .maintenance {


### PR DESCRIPTION
This PR fixes the spacing in the equipment panel so everything is even `spacing-4`. It also fixes a bug where the inoperable equipment panel was not scrolling.