### PR TITLE
fix(app): App title browser tab and favicon error fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "equpiment",
       "version": "0.1.0",
       "dependencies": {
-        "@astrouxds/mock-data": "^0.6.3",
+        "@astrouxds/mock-data": "^0.6.4",
         "@astrouxds/react": "^7.16.0",
-        "@astrouxds/tokens": "^1.9.0",
+        "@astrouxds/tokens": "^1.11.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@astrouxds/mock-data": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@astrouxds/mock-data/-/mock-data-0.6.3.tgz",
-      "integrity": "sha512-rW6tgLDNUU/E4hNgr02pIcl6s4RIv/XhMVf9O76hSBOGtripi2vJdFNkseSqHAYTGw2UZffgpRt/8eVDorvssA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@astrouxds/mock-data/-/mock-data-0.6.4.tgz",
+      "integrity": "sha512-GNbCz6AhitSdl4/OtHIC8r2KUIsOmVBlhcQFBlcJBXOhW4ZzrIRUyVMGXjYC7e2cb+WY37gqwhE0tJjLO1zOVA==",
       "dependencies": {
         "@faker-js/faker": "^8.0.2",
         "lodash": "^4.17.21"
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@astrouxds/tokens": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.9.0.tgz",
-      "integrity": "sha512-KdwwUK9RWSyvHZCukVO2nribo/SyPmzyNKZiZgNe7qR/S8xZctCnQsm2aAaD8ftfcFGyVdXnJiQRZfks6DlkJw=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.11.0.tgz",
+      "integrity": "sha512-JBZHAdrw3IZGqa2siasyyv5DUVUg/9nzw9EbRfXkDCCqFRyv1/ea9qRDki8h9sNobwDfwvRIzCgAQxDb1DaPgg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.5",
@@ -17776,9 +17776,9 @@
       }
     },
     "@astrouxds/mock-data": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@astrouxds/mock-data/-/mock-data-0.6.3.tgz",
-      "integrity": "sha512-rW6tgLDNUU/E4hNgr02pIcl6s4RIv/XhMVf9O76hSBOGtripi2vJdFNkseSqHAYTGw2UZffgpRt/8eVDorvssA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@astrouxds/mock-data/-/mock-data-0.6.4.tgz",
+      "integrity": "sha512-GNbCz6AhitSdl4/OtHIC8r2KUIsOmVBlhcQFBlcJBXOhW4ZzrIRUyVMGXjYC7e2cb+WY37gqwhE0tJjLO1zOVA==",
       "requires": {
         "@faker-js/faker": "^8.0.2",
         "lodash": "^4.17.21"
@@ -17793,9 +17793,9 @@
       }
     },
     "@astrouxds/tokens": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.9.0.tgz",
-      "integrity": "sha512-KdwwUK9RWSyvHZCukVO2nribo/SyPmzyNKZiZgNe7qR/S8xZctCnQsm2aAaD8ftfcFGyVdXnJiQRZfks6DlkJw=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@astrouxds/tokens/-/tokens-1.11.0.tgz",
+      "integrity": "sha512-JBZHAdrw3IZGqa2siasyyv5DUVUg/9nzw9EbRfXkDCCqFRyv1/ea9qRDki8h9sNobwDfwvRIzCgAQxDb1DaPgg=="
     },
     "@babel/code-frame": {
       "version": "7.22.5",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@astrouxds/mock-data": "^0.6.3",
+    "@astrouxds/mock-data": "^0.6.4",
     "@astrouxds/react": "^7.16.0",
-    "@astrouxds/tokens": "^1.9.0",
+    "@astrouxds/tokens": "^1.11.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>GRM Demo App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>GRM Demo App</title>
+    <title>GRM Equipment</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
This PR fixes the ‘React App’ title in the browser tab and removes un-used favicon declarations in the manifest.json file to fix the favicon error that was occurring.
[JIRA Ticket](https://rocketcom.atlassian.net/browse/DEMO-249)