### PR TITLE
Style Fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,6 +74,10 @@ rux-table-header {
   z-index: 10;
 }
 
+rux-table-header-cell {
+  cursor: pointer;
+}
+
 rux-status::part(status) {
   margin-inline: auto;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const router = createBrowserRouter(
           errorElement={<NoDataFound dataType='job' />}
         />
         <Route
-          path='job-details'
+          path='maintenance-details'
           element={<JobDetailsPage />}
           errorElement={<NoDataFound dataType='job' />}
         />

--- a/src/Components/AlertsPanel/Alerts.css
+++ b/src/Components/AlertsPanel/Alerts.css
@@ -55,6 +55,10 @@
   visibility: hidden;
 }
 
+.alert-list-headers span {
+  cursor: pointer;
+}
+
 .table-wrapper.alert-list::-webkit-scrollbar-track {
   margin-top: 0;
 }

--- a/src/Components/EquipmentDetailsPage/EquipmentDetailsPage.css
+++ b/src/Components/EquipmentDetailsPage/EquipmentDetailsPage.css
@@ -62,3 +62,7 @@
 .dashboard_equipment-wrapper rux-tab::part(container) {
   outline-offset: -1px;
 }
+
+.dashboard_equipment-wrapper rux-button::part(container) {
+    outline-offset: -3px;
+}

--- a/src/Components/EquipmentDetailsPage/EquipmentDetailsPage.css
+++ b/src/Components/EquipmentDetailsPage/EquipmentDetailsPage.css
@@ -3,6 +3,7 @@
   display: grid;
   grid-template-rows: max-content auto;
   grid-template-areas: 'tab-navigation' 'tab-panel';
+  height: calc(100% - 1px);
 }
 
 .dashboard_equipment-wrapper rux-tabs {
@@ -56,4 +57,8 @@
 
 .tabs-and-menu-wrapper rux-menu-item span rux-button rux-icon {
   margin: auto;
+}
+
+.dashboard_equipment-wrapper rux-tab::part(container) {
+  outline-offset: -1px;
 }

--- a/src/Components/EquipmentDetailsPanel/EquipmentDetailsPanel.tsx
+++ b/src/Components/EquipmentDetailsPanel/EquipmentDetailsPanel.tsx
@@ -60,7 +60,7 @@ const EquipmentDetailsPanel = () => {
         <RuxTextarea
           label='Description'
           size='large'
-          disabled
+          readonly
           value={capitalize(state.currentEquipment.description)}
         />
         <div className='equipment-details-log'>

--- a/src/Components/InoperableEquipment/InoperableEquipment.css
+++ b/src/Components/InoperableEquipment/InoperableEquipment.css
@@ -1,6 +1,5 @@
 .inoperable-equipment {
   color: var(--color-text-primary);
-  height: 100%;
 }
 
 .inoperable-equipment::part(body) {

--- a/src/Components/MaintenancePanel/JobIDCard/JobIDCard.tsx
+++ b/src/Components/MaintenancePanel/JobIDCard/JobIDCard.tsx
@@ -29,18 +29,21 @@ const JobIDCard = ({
         placeholder='Value'
         size='small'
         label='Job Type'
+        readonly
       />
       <RuxInput
         value={startTime}
         placeholder='YYY DDD HH:MM'
         size='small'
         label='Start'
+        readonly
       />
       <RuxInput
         value={stopTime}
         placeholder='YYY DDD HH:MM'
         size='small'
         label='Stop'
+        readonly
       />
       <RuxButton onClick={viewJob}>View Details</RuxButton>
     </RuxCard>

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.css
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.css
@@ -23,3 +23,7 @@
 .table-wrapper.jobs-table {
   max-height: 13rem;
 }
+
+.table-wrapper.jobs-table rux-table-row {
+  cursor: pointer;
+}

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.css
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.css
@@ -19,3 +19,7 @@
 .table-wrapper .jobs-cell:nth-of-type(1) {
   border-left: transparent 5px solid;
 }
+
+.table-wrapper.jobs-table {
+  max-height: 13rem;
+}

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
@@ -79,7 +79,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
 
   const handleTabeRowClick = (job: Job) => {
     dispatch({ type: 'EDIT_JOB', payload: job });
-    navigate('job-details');
+    navigate('maintenance-details');
   };
 
   return (

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
@@ -83,7 +83,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
   };
 
   return (
-    <div className='table-wrapper'>
+    <div className='table-wrapper jobs-table'>
       <RuxTable>
         <RuxTableHeader>
           <RuxTableHeaderRow>

--- a/src/Components/MaintenancePanel/MaintenancePanel.css
+++ b/src/Components/MaintenancePanel/MaintenancePanel.css
@@ -41,6 +41,8 @@ rux-container.schedule-job-wrapper {
   justify-content: space-between;
   flex-grow: 1;
   gap: var(--spacing-3);
+  max-height: 35rem;
+  overflow: auto;
 }
 
 .maintenance-history-panel {

--- a/src/Components/MaintenancePanel/MaintenancePanel.tsx
+++ b/src/Components/MaintenancePanel/MaintenancePanel.tsx
@@ -16,7 +16,7 @@ const MaintenancePanel = () => {
 
   const handleJobDetailsClick = (job: Job) => {
     dispatch({ type: 'EDIT_JOB', payload: job });
-    navigate('job-details');
+    navigate('maintenance-details');
   };
 
   const filteredJobs = state.currentEquipment

--- a/src/Components/MaintenancePanel/MaintenancePanel.tsx
+++ b/src/Components/MaintenancePanel/MaintenancePanel.tsx
@@ -61,17 +61,19 @@ const MaintenancePanel = () => {
           </RuxButton>
           <div className='job-card-wrapper'>
             {state.currentEquipment &&
-              filteredJobs.map((job: Job) => (
-                <JobIDCard
-                  key={job.jobId}
-                  type={job.jobType}
-                  id={Number(job.jobId)}
-                  startTime={job.startTime}
-                  stopTime={job.stopTime}
-                  status={capitalize(job.jobStatus) as string}
-                  viewJob={() => handleJobDetailsClick(job)}
-                />
-              ))}
+              filteredJobs
+                .reverse()
+                .map((job: Job) => (
+                  <JobIDCard
+                    key={job.jobId}
+                    type={job.jobType}
+                    id={Number(job.jobId)}
+                    startTime={job.startTime}
+                    stopTime={job.stopTime}
+                    status={capitalize(job.jobStatus) as string}
+                    viewJob={() => handleJobDetailsClick(job)}
+                  />
+                ))}
           </div>
         </div>
       </RuxContainer>


### PR DESCRIPTION
- Fix focus state on RuxTabs and "X" button within Tabs 
- Update all cursors to "pointer" where applicable (table header rows, alert list headers, Jobs table rows)
- Update breadcrumb title/path from "Job Details" to "Maintenance Details"
- Add readonly prop to job cards 
- Set max height and overflow auto for both job card and jobs table sections
- Have newest job card come in first (to the left of the oldest ones)
- Adjust Equipment Details container to be same height as Inoperable Equipment container
https://rocketcom.atlassian.net/browse/DEMO-266