### PR TITLE
Maintenance Panel

### DIFF
--- a/src/Components/JobDetails/JobDetails.css
+++ b/src/Components/JobDetails/JobDetails.css
@@ -14,6 +14,7 @@
 .jobs-wrapper rux-input::part(form-field) {
   flex-direction: row;
   width: 18rem;
+  align-items: center;
 }
 
 .jobs-wrapper rux-select::part(select) {

--- a/src/Components/MaintenancePanel/JobIDCard/JobIDCard.css
+++ b/src/Components/MaintenancePanel/JobIDCard/JobIDCard.css
@@ -19,6 +19,11 @@
   padding-top: var(--spacing-3);
 }
 
+.job-id-card rux-input::part(input) {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .job-id-card rux-input::part(label) {
   margin-right: var(--spacing-2);
   width: 90%;

--- a/src/Components/MaintenancePanel/JobIDCard/JobIDCard.tsx
+++ b/src/Components/MaintenancePanel/JobIDCard/JobIDCard.tsx
@@ -45,7 +45,9 @@ const JobIDCard = ({
         label='Stop'
         readonly
       />
-      <RuxButton onClick={viewJob}>View Details</RuxButton>
+      <RuxButton secondary onClick={viewJob}>
+        View Details
+      </RuxButton>
     </RuxCard>
   );
 };

--- a/src/Components/MaintenancePanel/MaintenancePanel.css
+++ b/src/Components/MaintenancePanel/MaintenancePanel.css
@@ -38,11 +38,15 @@ rux-container.schedule-job-wrapper {
   margin-top: 0px;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   flex-grow: 1;
-  gap: var(--spacing-3);
+  gap: var(--spacing-8);
   max-height: 35rem;
   overflow: auto;
+}
+
+.schedule-job-btn {
+  margin-right: var(--spacing-8);
 }
 
 .maintenance-history-panel {

--- a/src/Components/MaintenancePanel/MaintenancePanel.tsx
+++ b/src/Components/MaintenancePanel/MaintenancePanel.tsx
@@ -56,7 +56,10 @@ const MaintenancePanel = () => {
       <RuxContainer className='jobs-section'>
         <h2>Jobs</h2>
         <div className='schedule-job-wrapper'>
-          <RuxButton onClick={() => navigate('schedule-job')}>
+          <RuxButton
+            className='schedule-job-btn'
+            onClick={() => navigate('schedule-job')}
+          >
             Schedule Job
           </RuxButton>
           <div className='job-card-wrapper'>


### PR DESCRIPTION
Combined two tickets since the first one is a one-liner.
- Center align inputs in job details
https://rocketcom.atlassian.net/browse/DEMO-277

- Change job card alignment to flex-start (this solves the "odd placement" issue described in the ticket)
- Add ellipsis when text overflows in inputs
- Make "View Details" button secondary 
https://rocketcom.atlassian.net/browse/DEMO-275