### PR TITLE
fix(table): sorting caret for right-aligned columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "equpiment",
+  "name": "equipment",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "equpiment",
+      "name": "equipment",
       "version": "0.1.0",
       "dependencies": {
         "@astrouxds/mock-data": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "equpiment",
+  "name": "equipment",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/Components/JobDetails/JobDetails.tsx
+++ b/src/Components/JobDetails/JobDetails.tsx
@@ -342,7 +342,7 @@ const JobDetails = () => {
             after clicking "Calculate Conflicts".
           </span>
           <span>
-            To ensure that these contacts have the equpiment they need to
+            To ensure that these contacts have the equipment they need to
             execute, change the timeframe of the maintenance job using the
             Start/Stop fields, or change the equipment allocated to these
             contacts in the GRM Schedule app.

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.css
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.css
@@ -9,6 +9,14 @@
 .table-wrapper .jobs-cell:nth-of-type(4),
 .table-wrapper .jobs-cell:nth-of-type(3) {
   text-align: right;
+  /* width:15%; */
+}
+
+.table-wrapper .jobs-cell:nth-of-type(5) span,
+.table-wrapper .jobs-cell:nth-of-type(4) span,
+.table-wrapper .jobs-cell:nth-of-type(3) span {
+  /* 38px of padding to match icon and padding in header on right-aligned columns */
+  padding-inline-end: calc(var(--spacing-10) - var(--spacing-050));
 }
 
 rux-table-header-cell.jobs-header-cell:has(rux-icon.visible) div.right-align,
@@ -19,8 +27,8 @@ rux-table-header-cell.jobs-header-cell:hover div.right-align {
 
 rux-table-header-cell.jobs-header-cell:has(rux-icon.visible) div.right-align span,
 rux-table-header-cell.jobs-header-cell:hover div.right-align span {
-  width: calc(100% - 32px);
-  margin-left: auto;
+  /* width: calc(100% - 32px);
+  margin-left: auto; */
 }
 
 .table-wrapper .jobs-cell:nth-of-type(1) {

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.css
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.css
@@ -2,8 +2,10 @@
   width: 23%;
 }
 
-.table-wrapper rux-table-header-cell.jobs-header-cell.right-align
-.table-wrapper rux-table-cell.jobs-cell.right-align {
+.table-wrapper
+  rux-table-header-cell.jobs-header-cell.right-align
+  .table-wrapper
+  rux-table-cell.jobs-cell.right-align {
   text-align: right;
 }
 

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.css
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.css
@@ -2,33 +2,20 @@
   width: 23%;
 }
 
-.table-wrapper .jobs-header-cell:nth-of-type(3),
-.table-wrapper .jobs-header-cell:nth-of-type(4),
-.table-wrapper .jobs-header-cell:nth-of-type(5),
-.table-wrapper .jobs-cell:nth-of-type(5),
-.table-wrapper .jobs-cell:nth-of-type(4),
-.table-wrapper .jobs-cell:nth-of-type(3) {
+.table-wrapper rux-table-header-cell.jobs-header-cell.right-align
+.table-wrapper rux-table-cell.jobs-cell.right-align {
   text-align: right;
-  /* width:15%; */
 }
 
-.table-wrapper .jobs-cell:nth-of-type(5) span,
-.table-wrapper .jobs-cell:nth-of-type(4) span,
-.table-wrapper .jobs-cell:nth-of-type(3) span {
-  /* 38px of padding to match icon and padding in header on right-aligned columns */
-  padding-inline-end: calc(var(--spacing-10) - var(--spacing-050));
+.table-wrapper rux-table-cell.jobs-cell.right-align span {
+  /* 32px of padding to match icon and padding in header on right-aligned columns */
+  padding-inline-end: var(--spacing-8);
 }
 
 rux-table-header-cell.jobs-header-cell:has(rux-icon.visible) div.right-align,
 rux-table-header-cell.jobs-header-cell:hover div.right-align {
   width: fit-content;
   margin-left: auto;
-}
-
-rux-table-header-cell.jobs-header-cell:has(rux-icon.visible) div.right-align span,
-rux-table-header-cell.jobs-header-cell:hover div.right-align span {
-  /* width: calc(100% - 32px);
-  margin-left: auto; */
 }
 
 .table-wrapper .jobs-cell:nth-of-type(1) {

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
@@ -18,9 +18,9 @@ import './JobsTable.css';
 const columnDefs: any[] = [
   { label: 'Job ID', property: 'jobId' },
   { label: 'Type', property: 'jobType' },
-  { label: 'Created On', property: 'createdOn' },
-  { label: 'Started On', property: 'startTime' },
-  { label: 'Completed On', property: 'stopTime' },
+  { label: 'Created On', property: 'createdOn', isRightAligned: true, },
+  { label: 'Started On', property: 'startTime', isRightAligned: true, },
+  { label: 'Completed On', property: 'stopTime', isRightAligned: true, },
   { label: 'Technician', property: 'technician' },
   { label: 'Description', property: 'jobDescription' },
 ];
@@ -82,8 +82,6 @@ const JobsTable = ({ jobs }: PropTypes) => {
     navigate('maintenance-details');
   };
 
-  const rightAlignedColumns = ['createdOn', 'startTime', 'stopTime']
-
   return (
     <div className='table-wrapper'>
       <RuxTable>
@@ -94,11 +92,13 @@ const JobsTable = ({ jobs }: PropTypes) => {
                 key={`${colDef.property}${index}`}
                 data-sortprop={colDef.property}
                 onClick={handleHeaderCellClick}
-                className={ rightAlignedColumns.includes(colDef.property) ? 'jobs-header-cell right-align' : 'jobs-header-cell' }
+                className={
+                  colDef.isRightAligned
+                    ? 'jobs-header-cell right-align'
+                    : 'jobs-header-cell'
+                }
               >
-                <div
-                className={ rightAlignedColumns.includes(colDef.property) ? 'right-align' : '' }
-                >
+                <div className={colDef.isRightAligned ? 'right-align' : ''}>
                   <span>{colDef.label}</span>
                   <RuxIcon
                     icon={
@@ -123,19 +123,29 @@ const JobsTable = ({ jobs }: PropTypes) => {
                 key={`${job.jobId}${index}`}
                 onClick={() => handleTabeRowClick(job)}
               >
-                {columnDefs.map((colDef, index) => {
+                {columnDefs.map((colDef) => {
                   const property: keyof Job = colDef.property;
                   return (
-                    <RuxTableCell className={rightAlignedColumns.includes(colDef.property) ? 'jobs-cell right-align' : 'jobs-cell'} key={colDef.label}>
-                      <span className={ rightAlignedColumns.includes(colDef.property) ? 'right-align' : '' }>
-                      {property === 'jobDescription'
-                        ? capitalize(job[property])
-                        : property === 'createdOn' ||
-                          (property === 'startTime' && job[property] !== '') ||
-                          (property === 'stopTime' && job[property] !== '')
-                        ? setHhMmSs(job[property])
-                        : job[property]}
-                        </span>
+                    <RuxTableCell
+                      className={
+                        colDef.isRightAligned
+                          ? 'jobs-cell right-align'
+                          : 'jobs-cell'
+                      }
+                      key={colDef.label}
+                    >
+                      <span
+                        className={colDef.isRightAligned ? 'right-align' : ''}
+                      >
+                        {property === 'jobDescription'
+                          ? capitalize(job[property])
+                          : property === 'createdOn' ||
+                            (property === 'startTime' &&
+                              job[property] !== '') ||
+                            (property === 'stopTime' && job[property] !== '')
+                          ? setHhMmSs(job[property])
+                          : job[property]}
+                      </span>
                     </RuxTableCell>
                   );
                 })}

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
@@ -94,7 +94,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
                 key={`${colDef.property}${index}`}
                 data-sortprop={colDef.property}
                 onClick={handleHeaderCellClick}
-                className='jobs-header-cell'
+                className={ rightAlignedColumns.includes(colDef.property) ? 'jobs-header-cell right-align' : 'jobs-header-cell' }
               >
                 <div
                 className={ rightAlignedColumns.includes(colDef.property) ? 'right-align' : '' }
@@ -126,8 +126,8 @@ const JobsTable = ({ jobs }: PropTypes) => {
                 {columnDefs.map((colDef, index) => {
                   const property: keyof Job = colDef.property;
                   return (
-                    <RuxTableCell className='jobs-cell' key={colDef.label}>
-                      <span>
+                    <RuxTableCell className={rightAlignedColumns.includes(colDef.property) ? 'jobs-cell right-align' : 'jobs-cell'} key={colDef.label}>
+                      <span className={ rightAlignedColumns.includes(colDef.property) ? 'right-align' : '' }>
                       {property === 'jobDescription'
                         ? capitalize(job[property])
                         : property === 'createdOn' ||

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
@@ -141,10 +141,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
                       >
                         {property === 'jobDescription'
                           ? capitalize(job[property])
-                          : property === 'createdOn' ||
-                            (property === 'startTime' &&
-                              job[property] !== '') ||
-                            (property === 'stopTime' && job[property] !== '')
+                          : colDef.isRightAligned
                           ? setHhMmSs(job[property])
                           : job[property]}
                       </span>

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
@@ -35,6 +35,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
   const [sortDirection, setSortDirection] = useState<'ASC' | 'DESC'>('ASC');
   const [sortProp, setSortProp] = useState<keyof Job>('jobId');
   const [sortedData, setSortedData] = useState<Job[]>([]);
+  const [activeHeader, setActiveHeader] = useState<keyof Job>()
 
   const sortData = useCallback(
     (property: keyof Job, sortDirection: 'ASC' | 'DESC') => {
@@ -63,6 +64,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
   const handleHeaderCellClick = (event: React.MouseEvent<HTMLElement>) => {
     const target = event.currentTarget as HTMLElement;
     const sortProperty = target.dataset.sortprop as keyof Job;
+    setActiveHeader(sortProperty)
     if (sortProperty === sortProp) {
       // clicked same currently sorted column
       if (sortDirection === 'ASC') {
@@ -102,7 +104,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
                   <span>{colDef.label}</span>
                   <RuxIcon
                     icon={
-                      sortDirection === 'ASC'
+                      (sortDirection === 'ASC' || activeHeader !== colDef.property)
                         ? 'arrow-drop-down'
                         : 'arrow-drop-up'
                     }

--- a/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
+++ b/src/Components/MaintenancePanel/JobsTable/JobsTable.tsx
@@ -127,6 +127,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
                   const property: keyof Job = colDef.property;
                   return (
                     <RuxTableCell className='jobs-cell' key={colDef.label}>
+                      <span>
                       {property === 'jobDescription'
                         ? capitalize(job[property])
                         : property === 'createdOn' ||
@@ -134,6 +135,7 @@ const JobsTable = ({ jobs }: PropTypes) => {
                           (property === 'stopTime' && job[property] !== '')
                         ? setHhMmSs(job[property])
                         : job[property]}
+                        </span>
                     </RuxTableCell>
                   );
                 })}

--- a/src/Components/MaintenancePanel/ScheduleJob/ScheduleJob.tsx
+++ b/src/Components/MaintenancePanel/ScheduleJob/ScheduleJob.tsx
@@ -39,7 +39,7 @@ const ScheduleJob = () => {
   const randomStatus = Math.floor(Math.random() * statusValues.length);
   const randomJobStatus = Math.floor(Math.random() * jobValues.length);
   const equipmentValues = ['ANT3', 'BAFB4', 'ANT9', 'BAFB5', 'ANT12', 'BAFB8'];
-  const randomEqupiment = Math.floor(Math.random() * equipmentValues.length);
+  const randomEquipment = Math.floor(Math.random() * equipmentValues.length);
 
   const [newJob, setNewJob] = useState({
     jobId: uniqueJobId,
@@ -51,7 +51,7 @@ const ScheduleJob = () => {
     follow: true,
     jobStatus: jobValues[randomJobStatus],
     createdOn: Date.now(),
-    equipment: equipmentValues[randomEqupiment],
+    equipment: equipmentValues[randomEquipment],
     equipmentStatus: statusValues[randomStatus],
   });
 
@@ -210,7 +210,7 @@ const ScheduleJob = () => {
             <li>
               4. Would you like to follow this job? Following will send all
               updates and alerts from this job to the GRM Dashboard. If you do
-              not follow this job, you must view the job from the Equpiment
+              not follow this job, you must view the job from the Equipment
               Manager for any updates or alerts.
             </li>
             <li>
@@ -242,7 +242,7 @@ const ScheduleJob = () => {
             after clicking "Calculate Conflicts".
           </span>
           <span>
-            To ensure that these contacts have the equpiment they need to
+            To ensure that these contacts have the equipment they need to
             execute, change the timeframe of the maintenance job using the
             Start/Stop fields, or change the equipment allocated to these
             contacts in the GRM Schedule app.

--- a/src/common/Table/Table.css
+++ b/src/common/Table/Table.css
@@ -38,12 +38,9 @@
   grid-template-columns: 100% 0%;
 }
 
-.table-wrapper rux-table-header-cell div.right-align {
-  grid-template-columns: auto 32px;
-}
-
 .table-wrapper rux-table-header-cell:has(rux-icon.visible) div,
-.table-wrapper rux-table-header-cell:hover div {
+.table-wrapper rux-table-header-cell:hover div,
+.table-wrapper rux-table-header-cell div.right-align {
   grid-template-columns: auto 1fr;
 }
 
@@ -67,8 +64,6 @@ rux-container .table-wrapper {
   text-align: right;
 }
 
-/* to make up the difference for the sort icon in header cell */
-/* .table-wrapper rux-table-cell.right-align::after {
-  content: '';
-  padding-right: var(--spacing-8);
-} */
+rux-table-cell.right-align span.right-align {
+  padding-inline-end: var(--spacing-8);
+}

--- a/src/common/Table/Table.css
+++ b/src/common/Table/Table.css
@@ -39,9 +39,12 @@
 }
 
 .table-wrapper rux-table-header-cell:has(rux-icon.visible) div,
-.table-wrapper rux-table-header-cell:hover div,
-.table-wrapper rux-table-header-cell div.right-align {
+.table-wrapper rux-table-header-cell:hover div {
   grid-template-columns: auto 1fr;
+}
+
+.table-wrapper rux-table-header-cell div.right-align {
+  grid-template-columns: auto 32px;
 }
 
 .table-wrapper rux-table-header-cell span {

--- a/src/common/Table/Table.css
+++ b/src/common/Table/Table.css
@@ -42,7 +42,7 @@
 .table-wrapper rux-table-header-cell:hover div {
   grid-template-columns: auto 1fr;
 }
-
+.table-wrapper rux-table-header-cell:has(rux-icon.visible) div.right-align,
 .table-wrapper rux-table-header-cell div.right-align {
   grid-template-columns: auto 32px;
 }

--- a/src/common/Table/Table.css
+++ b/src/common/Table/Table.css
@@ -38,6 +38,10 @@
   grid-template-columns: 100% 0%;
 }
 
+.table-wrapper rux-table-header-cell div.right-align {
+  grid-template-columns: auto 32px;
+}
+
 .table-wrapper rux-table-header-cell:has(rux-icon.visible) div,
 .table-wrapper rux-table-header-cell:hover div {
   grid-template-columns: auto 1fr;
@@ -64,7 +68,7 @@ rux-container .table-wrapper {
 }
 
 /* to make up the difference for the sort icon in header cell */
-.table-wrapper rux-table-cell.right-align::after {
+/* .table-wrapper rux-table-cell.right-align::after {
   content: '';
   padding-right: var(--spacing-8);
-}
+} */

--- a/src/common/Table/Table.tsx
+++ b/src/common/Table/Table.tsx
@@ -21,7 +21,6 @@ const Table = ({ columnDefs, filteredData }: PropTypes) => {
   const [sortDirection, setSortDirection] = useState<'ASC' | 'DESC'>('ASC');
   const [sortProp, setSortProp] = useState<keyof Contact>('id');
   const [sortedData, setSortedData] = useState<Contact[]>([]);
-
   const sortData = useCallback(
     (property: keyof Contact, sortDirection: 'ASC' | 'DESC') => {
       const sortedData = [...filteredData].sort((a: Contact, b: Contact) => {

--- a/src/common/Table/TableBodyRow.tsx
+++ b/src/common/Table/TableBodyRow.tsx
@@ -16,11 +16,16 @@ const ContactsTable = ({ columnDefs, rowData }: PropTypes) => {
           ? colDef.valueFn(rowData[property])
           : rowData[property];
         return (
-          <RuxTableCell key={colDef.label}>
+          <RuxTableCell
+            key={colDef.label}
+            className={colDef.isRightAligned ? 'right-align' : ''}
+          >
             {property === 'status' ? (
               <RuxStatus status={cellValue}></RuxStatus>
             ) : (
-              cellValue
+              <span className={colDef.isRightAligned ? 'right-align' : ''}>
+                {cellValue}
+              </span>
             )}
           </RuxTableCell>
         );

--- a/src/common/Table/TableHeader.tsx
+++ b/src/common/Table/TableHeader.tsx
@@ -1,5 +1,5 @@
 import { RuxTableHeader, RuxTableHeaderRow } from '@astrouxds/react';
-import type { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import TableHeaderCell from './TableHeaderCell';
 import type { ColumnDef } from './Table';
 import type { Contact } from '@astrouxds/mock-data';
@@ -19,9 +19,11 @@ const TableHeader = ({
   sortProp,
   sortDirection,
 }: PropTypes) => {
+  const [activeHeader, setActiveHeader] = useState<keyof Contact>()
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     const target = event.currentTarget as HTMLElement;
     const sortProperty = target.dataset.sortprop as keyof Contact;
+    setActiveHeader(sortProperty);
     if (sortProperty === sortProp) {
       // clicked same currently sorted column
       if (sortDirection === 'ASC') {
@@ -46,6 +48,7 @@ const TableHeader = ({
             handleClick={handleClick}
             sortDirection={sortDirection}
             sortProp={sortProp}
+            activeHeader={activeHeader}
           />
         ))}
       </RuxTableHeaderRow>

--- a/src/common/Table/TableHeaderCell.tsx
+++ b/src/common/Table/TableHeaderCell.tsx
@@ -28,8 +28,9 @@ const TableHeaderCell = ({
       }
     >
       <div className={columnDefinition.isRightAligned ? 'right-align' : ''}>
-        <span>{columnDefinition.label}</span>
-
+        <span className={columnDefinition.isRightAligned ? 'right-align' : ''}>
+          {columnDefinition.label}
+        </span>
         <RuxIcon
           icon={sortDirection === 'ASC' ? 'arrow-drop-down' : 'arrow-drop-up'}
           size='32px'

--- a/src/common/Table/TableHeaderCell.tsx
+++ b/src/common/Table/TableHeaderCell.tsx
@@ -7,6 +7,7 @@ type PropTypes = {
   handleClick: React.MouseEventHandler<HTMLElement>;
   sortDirection: 'ASC' | 'DESC';
   sortProp: keyof Contact;
+  activeHeader: keyof Contact | undefined;
 };
 
 const TableHeaderCell = ({
@@ -14,6 +15,7 @@ const TableHeaderCell = ({
   handleClick,
   sortDirection,
   sortProp,
+  activeHeader,
 }: PropTypes) => {
   return (
     <RuxTableHeaderCell
@@ -32,7 +34,7 @@ const TableHeaderCell = ({
           {columnDefinition.label}
         </span>
         <RuxIcon
-          icon={sortDirection === 'ASC' ? 'arrow-drop-down' : 'arrow-drop-up'}
+          icon={(sortDirection === 'ASC' || activeHeader !== columnDefinition.property) ? 'arrow-drop-down' : 'arrow-drop-up'}
           size='32px'
           className={
             sortProp === columnDefinition.property ? 'visible' : 'hidden'

--- a/src/common/Table/TableHeaderCell.tsx
+++ b/src/common/Table/TableHeaderCell.tsx
@@ -19,9 +19,15 @@ const TableHeaderCell = ({
     <RuxTableHeaderCell
       data-sortprop={columnDefinition.property}
       onClick={handleClick}
-      className={columnDefinition.property === 'status' ? 'status-align' : ''}
+      className={
+        columnDefinition.property === 'status'
+          ? 'status-align'
+          : columnDefinition.isRightAligned
+          ? 'right-align'
+          : ''
+      }
     >
-      <div>
+      <div className={columnDefinition.isRightAligned ? 'right-align' : ''}>
         <span>{columnDefinition.label}</span>
 
         <RuxIcon


### PR DESCRIPTION
This PR is a modification of the latest caret fix. This allows the caret to take up space at all times, even when not visible on right-aligned columns. This makes it so the label will not be truncated unless necessary, and will not move when the caret is active. This fix also includes refactoring to use the `isRightAligned` boolean to check for column alignment and passing this into classes to be reflected in the css, some markup management to accommodate the change in both table header cells and table cells (table cells need to push 32px of padding on the right to maintain alignment for right-aligned columns.