### PR TITLE
fix(app): bundled fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -86,8 +86,6 @@ rux-status::part(status) {
 .filter-notification {
   background-color: var(--color-background-surface-default);
   padding: var(--spacing-2);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .filter-notification rux-button::part(container) {

--- a/src/Components/AlertsPanel/Alerts.tsx
+++ b/src/Components/AlertsPanel/Alerts.tsx
@@ -67,7 +67,7 @@ const Alerts = () => {
         className='filter-notification'
         hidden={severitySelection === 'all' && categorySelection === 'all'}
       >
-        One or more filters selected.
+        Filters selected.
         <RuxButton
           onClick={handleClearFilter}
           secondary

--- a/src/Components/EquipmentDetailsPage/EquipmentDetailsPage.css
+++ b/src/Components/EquipmentDetailsPage/EquipmentDetailsPage.css
@@ -26,6 +26,7 @@
 
 .tabs-and-menu-wrapper {
   display: flex;
+  overflow: scroll;
 }
 
 .tabs-and-menu-wrapper rux-icon {

--- a/src/Components/MaintenancePanel/MaintenancePanel.css
+++ b/src/Components/MaintenancePanel/MaintenancePanel.css
@@ -41,7 +41,7 @@ rux-container.schedule-job-wrapper {
   justify-content: flex-start;
   flex-grow: 1;
   gap: var(--spacing-8);
-  max-height: 35rem;
+  max-height: 37rem;
   overflow: auto;
 }
 

--- a/src/Components/MaintenancePanel/ScheduleJob/ScheduleJob.tsx
+++ b/src/Components/MaintenancePanel/ScheduleJob/ScheduleJob.tsx
@@ -11,7 +11,7 @@ import {
   RuxTable,
   RuxTableHeaderRow,
 } from '@astrouxds/react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppContext } from '../../../providers/AppProvider';
 import ConflictsTable from '../../JobDetails/ConflictsTable';
@@ -21,6 +21,7 @@ import { filterContacts } from '../../../utils/filterContacts';
 import './ScheduleJob.css';
 
 const ScheduleJob = () => {
+  
   const navigate = useNavigate();
   const { dispatch } = useAppContext() as any;
   const { dataArray: contacts } = useTTCGRMContacts();
@@ -55,6 +56,10 @@ const ScheduleJob = () => {
     equipmentStatus: statusValues[randomStatus],
   });
 
+  useEffect(() => {
+    if (newJob.startTime !== '' && newJob.stopTime !== '' && newJob.jobType !== '' && newJob.technician !== '') setInputsFilledOut(true);
+      }, [newJob]);
+
   const handleCancel = () => {
     navigate('/');
   };
@@ -70,7 +75,6 @@ const ScheduleJob = () => {
       ...prevState,
       [e.target.name]: e.target.value,
     }));
-    setInputsFilledOut(true);
   };
 
   const handleTechSelection = (e: any) => {
@@ -81,7 +85,6 @@ const ScheduleJob = () => {
       ...prevState,
       [e.target.name]: e.target.value,
     }));
-    setInputsFilledOut(true);
   };
 
   const handleJobSelection = (e: any) => {
@@ -92,7 +95,6 @@ const ScheduleJob = () => {
       ...prevState,
       [e.target.name]: e.target.value,
     }));
-    setInputsFilledOut(true);
   };
 
   const handleJobInput = (e: any) => {
@@ -110,7 +112,6 @@ const ScheduleJob = () => {
       ...prevState,
       [e.target.name]: e.target.value,
     }));
-    setInputsFilledOut(true);
   };
 
   const filteredContacts = useMemo(() => {

--- a/src/common/EventLog/EventLog.css
+++ b/src/common/EventLog/EventLog.css
@@ -2,6 +2,8 @@
   height: 98%;
   width: 100%;
   display: flex;
+  border-bottom: 1px solid black;
+  border-top: 1px solid black;
 }
 
 rux-log {


### PR DESCRIPTION
This PR handles the following fixes (tickets):
- Making a new job was allowed with only a job type, making the maintenance history table show up with weird values. The fix was to change the setting for the calculate conflict button to only go active once the necessary values had more than an empty string.
- Jobs cards were cutoff when two rows of jobs were showing
- Alerts list filter message was cutoff on smaller viewport widths
- Adding tabs was increasing the width of the content past the viewport if the viewport was small enough.